### PR TITLE
Exposed navigationFooterView (in ResearchKit.Private)

### DIFF
--- a/ResearchKit/Common/ORKStepViewController_Internal.h
+++ b/ResearchKit/Common/ORKStepViewController_Internal.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)stepDidChange;
 
+@property (nonatomic, strong, nullable) ORKNavigationContainerView *navigationFooterView;
+
 @property (nonatomic, copy, nullable) NSURL *outputDirectory;
 @property (nonatomic, copy, readonly, nullable) NSArray <ORKResult *> *addedResults;
 


### PR DESCRIPTION
This is necessary in order to add navigationFooterView to MW PDF step.