### PR TITLE
[MW-135] Trimming whitespaces from textFields on end editing

### DIFF
--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -774,6 +774,8 @@ static const CGFloat InlineFormItemLabelToTextFieldPadding = 10.0;
      postNotificationName:ORKResetDoneButtonKey
      object:self];
     
+    textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    
     if (textField.text.length > 0 && ![[self.formItem impliedAnswerFormat] isAnswerValidWithString:textField.text]) {
         [self updateErrorLabelWithMessage:[[self.formItem impliedAnswerFormat] localizedInvalidValueStringWithAnswerString:@""]];
         return YES;

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -659,6 +659,9 @@ static const CGFloat CellBottomPadding = 5.0;
 }
 
 - (void)textFieldDidEndEditing:(UITextField *)textField {
+    textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    [self checkTextAndSetAnswer];
+    
     NSString *text = self.textField.text;
     ORKTextAnswerFormat *answerFormat = (ORKTextAnswerFormat *)[self.step impliedAnswerFormat];
     


### PR DESCRIPTION
This fixes validation error when pasting email with trailing space, but I think it's desirable behaviour in general.